### PR TITLE
refactor(multi-module): extract shared Docker utilities

### DIFF
--- a/.github/workflows/ci-scripts-cli-installer.yaml
+++ b/.github/workflows/ci-scripts-cli-installer.yaml
@@ -89,6 +89,12 @@ jobs:
           name: build-artifacts-scripts-cli-installer
           path: out/build/scripts-cli-installer
 
+      - name: Download R2R CLI Build Artifacts (Test Dependency)
+        uses: actions/download-artifact@v6
+        with:
+          name: build-artifacts-r2r-cli
+          path: out/build/r2r-cli
+
       - name: Test Module (Commit Suite - L0-L2)
         shell: pwsh
         run: |

--- a/go/eac/commands/impl/build/books/mermaid.go
+++ b/go/eac/commands/impl/build/books/mermaid.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/ready-to-release/eac/go/eac/commands/impl/build/buildutil"
 )
 
 // Size presets for mermaid diagrams
@@ -237,6 +239,15 @@ type cacheStatus struct {
 // renderSingleDiagram renders a single mermaid diagram to SVG using mermaid-cli
 // Returns error if rendering fails
 func renderSingleDiagram(block mermaidBlock, outputPath string, workspaceRoot string, logWriter io.Writer) error {
+	// Detect Docker-in-Docker mode
+	isDinD := buildutil.IsDockerInDocker()
+	hostRepoRoot := workspaceRoot
+	if isDinD {
+		if hostRoot := os.Getenv("R2R_HOST_REPOROOT"); hostRoot != "" {
+			hostRepoRoot = hostRoot
+		}
+	}
+
 	// Create temp file for mermaid content
 	tmpDir := filepath.Dir(outputPath)
 	tmpFile := filepath.Join(tmpDir, block.filename+".mmd")
@@ -261,8 +272,8 @@ func renderSingleDiagram(block mermaidBlock, outputPath string, workspaceRoot st
 	dockerTmpFile := "/docs/" + strings.ReplaceAll(relTmpFile, "\\", "/")
 	dockerOutputPath := "/docs/" + strings.ReplaceAll(relOutputPath, "\\", "/")
 
-	// Format Docker volume path
-	dockerVolume := formatDockerVolumePath(workspaceRoot)
+	// Format Docker volume path using host paths for DinD
+	dockerVolume := buildutil.FormatDockerVolumePath(hostRepoRoot)
 
 	// Build Docker command
 	// Use cli-mkdocs-pdf container which has mermaid-cli installed
@@ -280,6 +291,15 @@ func renderSingleDiagram(block mermaidBlock, outputPath string, workspaceRoot st
 		"-t", "dark",        // Theme (dark for PDF)
 		"-b", "transparent", // Background
 		"--configFile", "/docs/containers/mkdocs-pdf/mermaid-config.json", // Disable htmlLabels for PDF compatibility
+	}
+
+	// Add user spec in DinD mode to avoid permission issues
+	if isDinD {
+		uid := os.Getuid()
+		gid := os.Getgid()
+		userSpec := fmt.Sprintf("%d:%d", uid, gid)
+		// Insert --user after "run" and "--rm"
+		args = append([]string{"run", "--rm", "--user", userSpec}, args[2:]...)
 	}
 
 	// Run docker command
@@ -303,25 +323,21 @@ func renderSingleDiagram(block mermaidBlock, outputPath string, workspaceRoot st
 	return nil
 }
 
-// formatDockerVolumePath formats a path for Docker volume mounting
-// Handles Windows paths (C:\path -> /c/path) and Unix paths
-func formatDockerVolumePath(path string) string {
-	// Convert backslashes to forward slashes
-	path = filepath.ToSlash(path)
-
-	// Handle Windows drive letters (C: -> /c)
-	if len(path) >= 2 && path[1] == ':' {
-		drive := strings.ToLower(string(path[0]))
-		path = "/" + drive + path[2:]
-	}
-
-	return path
-}
-
 // renderMermaidDiagrams renders multiple mermaid diagrams in parallel
 // Only renders cache misses (cached diagrams are skipped)
 // Returns number of diagrams rendered and any error
 func (p *Preprocessor) renderMermaidDiagrams(statuses []cacheStatus) (int, error) {
+	// Check Docker availability first - fail fast if unavailable
+	if !buildutil.IsDockerAvailable() {
+		errorMsg := "Docker is not available but required for mermaid diagram rendering"
+		if buildutil.IsDockerInDocker() {
+			errorMsg += "\nRunning in container: mount Docker socket with -v /var/run/docker.sock:/var/run/docker.sock"
+		} else {
+			errorMsg += "\nEnsure Docker is installed and the daemon is running"
+		}
+		return 0, fmt.Errorf("%s", errorMsg)
+	}
+
 	// Filter for cache misses
 	toRender := []cacheStatus{}
 	for _, status := range statuses {

--- a/go/eac/commands/impl/build/books/mermaid_test.go
+++ b/go/eac/commands/impl/build/books/mermaid_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/ready-to-release/eac/go/eac/commands/impl/build/buildutil"
 )
 
 func TestExtractMermaidBlocks(t *testing.T) {
@@ -359,9 +361,9 @@ func TestFormatDockerVolumePath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := formatDockerVolumePath(tt.input)
+			result := buildutil.FormatDockerVolumePath(tt.input)
 			if result != tt.expected {
-				t.Errorf("formatDockerVolumePath(%q) = %q, want %q",
+				t.Errorf("buildutil.FormatDockerVolumePath(%q) = %q, want %q",
 					tt.input, result, tt.expected)
 			}
 		})

--- a/go/eac/commands/impl/build/builders/docker.go
+++ b/go/eac/commands/impl/build/builders/docker.go
@@ -35,9 +35,9 @@ func BuildDockerModule(module *modules.ModuleContract, workspaceRoot string, out
 	Logln(logWriter, "\n=== Building %s: %s ===", module.Type, module.Moniker)
 
 	// Check if Docker is available before attempting to build
-	if !isDockerAvailable() {
+	if !IsDockerAvailable() {
 		Logln(logWriter, "❌ Docker is not available")
-		if isDockerInDocker() {
+		if IsDockerInDocker() {
 			Logln(logWriter, "   Container detected but Docker socket not mounted")
 			Logln(logWriter, "   Ensure the Docker socket is mounted (-v /var/run/docker.sock:/var/run/docker.sock)")
 		} else {
@@ -136,7 +136,7 @@ func getGitShortSHA(workspaceRoot string) string {
 // buildDockerLocal builds a Docker image locally using BuildKit for cache support
 func buildDockerLocal(workspaceRoot string, outputDir string, dockerfilePath string, tags []string, logWriter io.Writer) int {
 	// Check for Docker-in-Docker mode
-	isDinD := isDockerInDocker()
+	isDinD := IsDockerInDocker()
 	var contextPath, dockerfileArg string
 
 	if isDinD {
@@ -260,12 +260,4 @@ func buildDockerCI(module *modules.ModuleContract, workspaceRoot string, outputD
 	}
 
 	return 0
-}
-
-// isDockerAvailable checks if Docker daemon is accessible
-func isDockerAvailable() bool {
-	cmd := exec.Command("docker", "info")
-	cmd.Stdout = nil
-	cmd.Stderr = nil
-	return cmd.Run() == nil
 }

--- a/go/eac/commands/impl/build/builders/go.go
+++ b/go/eac/commands/impl/build/builders/go.go
@@ -188,35 +188,6 @@ func buildSingleBinary(module *modules.ModuleContract, moduleRoot string, worksp
 	return exitCode
 }
 
-// isDockerInDocker detects if we're running inside a Docker container.
-// Uses multiple signals for robust detection:
-// 1. R2R_DOCKER_MODE env var (set by r2r CLI when launching containers)
-// 2. R2R_HOST_REPOROOT with Windows path while running on Linux (indicates container)
-// 3. /.dockerenv file exists (standard Docker container indicator)
-func isDockerInDocker() bool {
-	// Primary check: explicit env var
-	if os.Getenv("R2R_DOCKER_MODE") == "true" {
-		return true
-	}
-
-	// Fallback: R2R_HOST_REPOROOT is set with Windows path but we're on Linux
-	// This catches old r2r CLI binaries that don't set R2R_DOCKER_MODE
-	hostRoot := os.Getenv("R2R_HOST_REPOROOT")
-	if hostRoot != "" && runtime.GOOS == "linux" {
-		// Windows paths have backslashes or drive letters
-		if strings.Contains(hostRoot, "\\") || (len(hostRoot) >= 2 && hostRoot[1] == ':') {
-			return true
-		}
-	}
-
-	// Final fallback: check for Docker container indicator file
-	if _, err := os.Stat("/.dockerenv"); err == nil {
-		return true
-	}
-
-	return false
-}
-
 // getHostPlatform returns the host's GOOS and GOARCH when running in a container.
 // Uses R2R_HOST_GOOS and R2R_HOST_GOARCH env vars set by r2r CLI.
 func getHostPlatform() (goos, goarch string) {

--- a/go/eac/commands/impl/build/builders/helpers.go
+++ b/go/eac/commands/impl/build/builders/helpers.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
+	"github.com/ready-to-release/eac/go/eac/commands/impl/build/buildutil"
 	"github.com/ready-to-release/eac/go/eac/core/config"
 	"github.com/ready-to-release/eac/go/eac/core/platform"
 )
@@ -91,12 +92,17 @@ func CopyFile(src, dst string) error {
 // FormatDockerVolumePath formats a path for use as a Docker volume mount source
 // On Windows, converts C:\path to /c/path for Docker compatibility
 func FormatDockerVolumePath(path string) string {
-	if len(path) >= 2 && path[1] == ':' {
-		driveLetter := strings.ToLower(string(path[0]))
-		rest := strings.ReplaceAll(path[2:], "\\", "/")
-		return "/" + driveLetter + rest
-	}
-	return strings.ReplaceAll(path, "\\", "/")
+	return buildutil.FormatDockerVolumePath(path)
+}
+
+// IsDockerInDocker detects if we're running inside a Docker container
+func IsDockerInDocker() bool {
+	return buildutil.IsDockerInDocker()
+}
+
+// IsDockerAvailable checks if Docker daemon is accessible
+func IsDockerAvailable() bool {
+	return buildutil.IsDockerAvailable()
 }
 
 // BuildMarkerFilename is the standard name for build completion markers

--- a/go/eac/commands/impl/build/builders/mkdocs.go
+++ b/go/eac/commands/impl/build/builders/mkdocs.go
@@ -101,7 +101,7 @@ func BuildMkDocsModule(module *modules.ModuleContract, workspaceRoot string, out
 	// When running inside a container, the Docker daemon runs on the host,
 	// so volume mounts need host paths instead of container paths
 	hostRepoRoot := workspaceRoot
-	isDinD := isDockerInDocker()
+	isDinD := IsDockerInDocker()
 	if isDinD {
 		if hostRoot := os.Getenv("R2R_HOST_REPOROOT"); hostRoot != "" {
 			hostRepoRoot = hostRoot
@@ -501,7 +501,7 @@ func buildHTMLWithStaging(module *modules.ModuleContract, workspaceRoot string, 
 
 	// Docker setup
 	hostRepoRoot := workspaceRoot
-	isDinD := isDockerInDocker()
+	isDinD := IsDockerInDocker()
 	if isDinD {
 		if hostRoot := os.Getenv("R2R_HOST_REPOROOT"); hostRoot != "" {
 			hostRepoRoot = hostRoot
@@ -637,7 +637,7 @@ func buildMkDocsWithThemeAndStaging(module *modules.ModuleContract, bookName str
 
 	// For Docker-in-Docker: use host path for volume mount
 	hostRepoRoot := workspaceRoot
-	isDinD := isDockerInDocker()
+	isDinD := IsDockerInDocker()
 	if isDinD {
 		if hostRoot := os.Getenv("R2R_HOST_REPOROOT"); hostRoot != "" {
 			hostRepoRoot = hostRoot

--- a/go/eac/commands/impl/build/buildutil/docker.go
+++ b/go/eac/commands/impl/build/buildutil/docker.go
@@ -1,0 +1,58 @@
+// docker.go - Shared Docker utilities for build system
+package buildutil
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// IsDockerInDocker detects if we're running inside a Docker container.
+// Uses multiple signals for robust detection:
+// 1. R2R_DOCKER_MODE env var (set by r2r CLI when launching containers)
+// 2. R2R_HOST_REPOROOT with Windows path while running on Linux (indicates container)
+// 3. /.dockerenv file exists (standard Docker container indicator)
+func IsDockerInDocker() bool {
+	// Primary check: explicit env var
+	if os.Getenv("R2R_DOCKER_MODE") == "true" {
+		return true
+	}
+
+	// Fallback: R2R_HOST_REPOROOT is set with Windows path but we're on Linux
+	// This catches old r2r CLI binaries that don't set R2R_DOCKER_MODE
+	hostRoot := os.Getenv("R2R_HOST_REPOROOT")
+	if hostRoot != "" && runtime.GOOS == "linux" {
+		// Windows paths have backslashes or drive letters
+		if strings.Contains(hostRoot, "\\") || (len(hostRoot) >= 2 && hostRoot[1] == ':') {
+			return true
+		}
+	}
+
+	// Final fallback: check for Docker container indicator file
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+
+	return false
+}
+
+// IsDockerAvailable checks if Docker daemon is accessible by attempting to run 'docker info'.
+// Returns true if Docker daemon is accessible, false otherwise.
+func IsDockerAvailable() bool {
+	cmd := exec.Command("docker", "info")
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Run() == nil
+}
+
+// FormatDockerVolumePath formats a path for use as a Docker volume mount source
+// On Windows, converts C:\path to /c/path for Docker compatibility
+func FormatDockerVolumePath(path string) string {
+	if len(path) >= 2 && path[1] == ':' {
+		driveLetter := strings.ToLower(string(path[0]))
+		rest := strings.ReplaceAll(path[2:], "\\", "/")
+		return "/" + driveLetter + rest
+	}
+	return strings.ReplaceAll(path, "\\", "/")
+}


### PR DESCRIPTION
Auditor-Summary: Moved Docker detection and path formatting logic to reusable buildutil package to eliminate code duplication.

This commit consolidates Docker-related utilities (IsDockerInDocker, IsDockerAvailable, FormatDockerVolumePath) into a new buildutil package. Updates mermaid rendering to use centralized utilities and adds Docker availability checks with improved error messaging for container environments.
Changes: 8 files, +119 insertions, -68 deletions

scripts-cli-installer
------------
scripts-cli-installer: chore: add R2R CLI artifact download to test

workflow Added download step for R2R CLI build artifacts as a test dependency in the CI workflow. This ensures the required R2R CLI binary is available when running the scripts-cli-installer test suite.

---

eac-commands
------------
eac-commands: refactor: extract Docker utilities to buildutil package

Moved Docker detection and path formatting functions from multiple builder modules into a centralized buildutil package for reusability. Updated mermaid rendering to detect Docker-in-Docker mode and handle host paths correctly when running in containers.