### PR TITLE
fix(multi-module): cross-shell compatibility for importer and go-invoker

### DIFF
--- a/importer.sh
+++ b/importer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # importer.sh - Import the go-invoker module and optionally create 'run' alias
 #
@@ -15,7 +15,14 @@
 # Note:
 #   Must be sourced (source ./importer.sh) for the alias to work in your session.
 
-set -e
+# Check if the script is being sourced
+# This works in both Bash and Zsh by testing if 'return' is allowed
+(return 0 2>/dev/null) && IS_SOURCED=1 || IS_SOURCED=0
+
+if [ "$IS_SOURCED" -eq 0 ]; then
+    echo "This script must be sourced: source ./importer.sh" >&2
+    exit 1
+fi
 
 # Parse arguments
 NO_ALIAS=0
@@ -36,11 +43,14 @@ MODULE_PATH="$SCRIPT_DIR/scripts/sh/go-invoker/go.sh"
 # Check if module exists
 if [ ! -f "$MODULE_PATH" ]; then
     echo "Error: Module not found at: $MODULE_PATH" >&2
-    return 1 2>/dev/null || exit 1
+    return 1
 fi
 
 # Source the module
-source "$MODULE_PATH"
+if ! source "$MODULE_PATH"; then
+    echo "Error: Failed to source module at: $MODULE_PATH" >&2
+    return 1
+fi
 
 # Show welcome only once per session
 if [ "$SHOW_WELCOME" -eq 1 ]; then

--- a/scripts/sh/go-invoker/go.sh
+++ b/scripts/sh/go-invoker/go.sh
@@ -7,8 +7,14 @@
 #   get_go_src_commands                              - List available commands
 #   new_run_alias                                    - Create 'run' alias
 
-# Get repository root (three levels up from this script)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Get repository root
+if [ -n "$ZSH_VERSION" ]; then
+    # Zsh specific way to get current script path
+    SCRIPT_DIR="${0:a:h}"
+else
+    # Bash specific way
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fi
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 #
@@ -98,7 +104,9 @@ new_run_alias() {
     fi
 }
 
-# Export functions so they can be used after sourcing
-export -f invoke_go_src_command
-export -f get_go_src_commands
-export -f new_run_alias
+# Export functions so they can be used after sourcing (Bash only)
+if [ -n "$BASH_VERSION" ]; then
+    export -f invoke_go_src_command
+    export -f get_go_src_commands
+    export -f new_run_alias
+fi


### PR DESCRIPTION
Auditor-Summary: Makes importer.sh and go.sh to work reliably in both Bash and Zsh on Linux and macOS.

Making both importer.sh and go.sh to work reliably in both Bash and Zsh on Linux and macOS. Replaces Bash-specific logic with a portable return test for sourcing detection and robust path calculation. Simplifies error handling to prevent accidental terminal exits during sourcing.