### PR TITLE
chore: add Junie agent configuration

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -7,14 +7,17 @@
 1. **Detect current workspace** from the environment context (current branch and working directory are provided in `<env>` and `gitStatus`)
 2. **Verify workspace context**: Check if the current directory path matches the detected branch (may be a mismatch in multi-worktree setups)
 3. **Read this file** (`/agent.md`) to load project context
-4. **Verify MCP server availability**:
+4. **Junie-Specific Initialization**: If you are Junie, you MUST:
+   - Read `./junie/README.md` and all files in `./junie/` following the load order defined in `junie/README.md`
+   - Apply `./junie/` instructions as overrides to this file (`agent.md`) where contradictions exist
+5. **Verify MCP server availability**:
    - Check your available tool list for `mcp__commands__*` tools (Commands Server)
    - Check your available tool list for `mcp__github__*` tools (GitHub Server)
    - Determine connection status for each: CONNECTED or NOT CONNECTED
    - Set execution mode accordingly (MCP-First or CLI Fallback)
-5. **Internalize all constraints and guidelines** defined below
-6. **Apply these instructions** throughout the entire session
-7. **Confirm initialization** with a flashy initialization report using this format:
+6. **Internalize all constraints and guidelines** defined below
+7. **Apply these instructions** throughout the entire session
+8. **Confirm initialization** with a flashy initialization report using this format:
 
 ```text
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓

--- a/junie/README.md
+++ b/junie/README.md
@@ -1,0 +1,24 @@
+# Junie Project Instructions
+
+Purpose: Source of truth for Junie‑specific guidance. Complements `agent.md` and may override it where noted.
+
+Load order (highest precedence first):
+1. `overrides.md`
+2. `rules/*.md`
+3. `modes.md`
+4. `glossary.md`
+5. This `README.md`
+
+Baseline:
+- Junie must first read the repository root `agent.md` for canonical project context.
+- After that, Junie must read all files under `./junie/` using the load order above.
+- If any instruction conflicts with `agent.md`, the instruction from `./junie/` takes precedence.
+
+Scope:
+- Persistent, project‑scoped instructions for Junie.
+- Not for temporary notes or logs.
+
+Maintenance:
+- Keep guidance concise and actionable.
+- Prefer small, focused rule files under `junie/rules/`.
+- Update `overrides.md` whenever precedence rules change.

--- a/junie/glossary.md
+++ b/junie/glossary.md
@@ -1,0 +1,12 @@
+# Glossary
+
+Add project‑specific terms and acronyms here to normalize language across answers and code.
+
+Examples
+- EAC — Everything as Code (the system used in this repo)
+- MCP — Model Context Protocol
+- R2R — Repository‑to‑Release CLI
+
+Conventions
+- Prefer singular term definitions with short, precise meanings.
+- Reference related docs in `docs/` when useful.

--- a/junie/modes.md
+++ b/junie/modes.md
@@ -1,0 +1,20 @@
+# Modes
+
+Default behavior
+- Start in the minimal mode that can satisfy the request safely and efficiently.
+- Escalate modes only when necessary per the decision tree below.
+
+Decision Tree (summary)
+1. [CHAT] — Greetings, small talk, quick factual questions.
+2. [ADVANCED_CHAT] — Read‑only repo analysis/advice; may read files, no edits.
+3. [RUN_VERIFY] — Run app/tests or short safe commands; no edits.
+4. [FAST_CODE] — Truly trivial change (1–3 steps, single file), no extra investigation.
+5. [CODE] — Anything non‑trivial: multi‑file, tests, or investigation needed.
+6. [SETUP] — Install/build/configure/fix environment; no significant app code.
+7. [NICHE] — Specialized forensics/reverse‑engineering tasks only.
+
+Switching Rules
+- [CHAT]/[ADVANCED_CHAT]: never switch mid‑step; finish answer.
+- [FAST_CODE]: switch to [CODE] if not done in 3 steps.
+- [RUN_VERIFY]: switch to [CODE] if not done in 3 steps.
+- [SETUP]/[NICHE]: may switch to [CODE] if significant code changes become necessary.

--- a/junie/overrides.md
+++ b/junie/overrides.md
@@ -1,0 +1,30 @@
+# Overrides
+
+These rules explicitly take precedence over any conflicting guidance in `agent.md`.
+
+Precedence Policy
+- Source order: `junie/overrides.md` > `junie/rules/*.md` > `junie/modes.md` > `junie/glossary.md` > `junie/README.md` > `agent.md`.
+- If a conflict is detected, prefer the earliest item in the order above.
+
+Session Initialization
+- Always read `agent.md` first.
+- Then read `junie/README.md` and all files under `junie/` following the load order above.
+
+Claude Workflows Non‑Duplication (MANDATORY)
+- Be aware of and reference existing workflows defined for Claude in `.claude/agents/`, `.claude/commands/`, and `.claude/skills/`.
+- Do NOT copy, mirror, or migrate these files into `junie/`.
+- When execution is requested, read and follow the `.claude/` sources in place.
+- Prefer MCP tools when connected; otherwise use CLI fallbacks as defined in `agent.md`.
+
+File Modification Permission (MANDATORY)
+- Do not create, edit, move, or delete any files without explicit confirmation from the user for that specific action.
+- Before any file system change, pause and ask for permission, summarizing the intended change, affected paths, and rationale.
+
+Commit Reminder Between Tasks (MANDATORY)
+- When finishing a task or when the user changes topic/scope, proactively ask whether to commit current work to git before proceeding.
+- Encourage small, atomic commits with clear messages; offer to stage only the touched files/modules.
+
+Operational Safeguards
+- Do not run destructive commands without explicit confirmation from the user.
+- Keep changes minimal and targeted; avoid broad refactors unless requested.
+- Prefer explanations that include trade‑offs when multiple options are viable.

--- a/junie/rules/conventions.md
+++ b/junie/rules/conventions.md
@@ -1,0 +1,16 @@
+# Conventions
+
+Style & Communication
+- Be concise by default; expand on request.
+- Use the project's language and tone; mirror code style of touched files.
+- Prefer explicit, intention‑revealing names in examples and code.
+
+Change Discipline
+- Minimize diff size; isolate unrelated changes.
+- Avoid broad refactors unless explicitly requested.
+- When multiple valid approaches exist, summarize trade‑offs and recommend one.
+
+Quality Bars (Lightweight)
+- Keep functions small and focused.
+- Add or update tests proportionally to risk.
+- Explain any notable deviations from existing patterns.

--- a/junie/rules/tools.md
+++ b/junie/rules/tools.md
@@ -1,0 +1,7 @@
+# Tools & Execution
+
+- Prefer specialized project tools over general commands when available.
+- Use non‑interactive flags (`-y`, `--yes`, `--non-interactive`) for any command that may prompt.
+- Keep commands self‑contained and short; avoid background daemons unless explicitly needed.
+- Respect repository structure; do not write outside the project root.
+- Timeouts: choose conservative, realistic timeouts rather than maximums.

--- a/junie/rules/workflows.md
+++ b/junie/rules/workflows.md
@@ -1,0 +1,41 @@
+# Workflows
+
+Session Start
+1. Read `agent.md`.
+2. Read `junie/README.md`.
+3. Read all `junie/rules/*.md`.
+4. Read `junie/modes.md` and `junie/glossary.md`.
+5. Apply precedence from `junie/overrides.md`.
+
+Mode Selection
+- Prefer minimal mode needed:
+  - Quick Q&A → [CHAT]
+  - Repo analysis/advice without edits → [ADVANCED_CHAT]
+  - Run tests/app or short checks → [RUN_VERIFY]
+  - Single, trivial edit (≤3 steps, one file) → [FAST_CODE]
+  - Anything larger/multi‑file or needs investigation → [CODE]
+  - Environment/setup tasks → [SETUP]
+
+External Workflows Awareness & Non‑duplication
+- Source of truth for Claude workflows lives under `.claude/`:
+  - Agents: `.claude/agents/*.md`
+  - Commands (slash workflows): `.claude/commands/*.md`
+  - Skills (multi‑step workflows): `.claude/skills/*.md`
+- Junie must not copy, mirror, or migrate these files into `junie/`.
+- When a user asks to run or follow an existing workflow defined for Claude:
+  - Read the relevant `.claude/` file(s) in place and follow their guidance.
+  - Prefer MCP servers when available; otherwise use CLI fallbacks as defined in `agent.md`.
+  - For discovery, list or reference available items by reading directory contents or documented indexes; do not duplicate their content in responses beyond what’s necessary to execute the workflow.
+- Workflows that do not require an upstream LLM:
+  - Prefer MCP tools (`mcp__commands__*`, `mcp__github__*`) when CONNECTED.
+  - If NOT CONNECTED, use documented CLI fallbacks (e.g., `go run ./go/cli/eac <command>`), per `agent.md`.
+  - Keep execution non‑interactive and scoped.
+
+Task Switching Protocol
+- When a task is completed or the user changes topic/scope, pause to confirm whether to commit current work before proceeding.
+- Recommend small, atomic commits with descriptive messages.
+- Offer to stage only the relevant files/modules.
+
+Verification
+- When changes are made, run the smallest sufficient verification (tests/build) required by the change risk.
+- Never submit with failing builds/tests without explicit user approval.


### PR DESCRIPTION
Adds project-scoped Junie configuration and guidance files to standardize assistant behavior for this repository. No production code paths are affected; documentation-only change under `junie/`.

#### What’s in this PR
- Add Junie project instructions and rules:
  - `junie/README.md`
  - `junie/overrides.md`
  - `junie/modes.md`
  - `junie/glossary.md`
  - `junie/rules/conventions.md`
  - `junie/rules/tools.md`
  - `junie/rules/workflows.md`
- Aligns with repo workflow conventions (Conventional Commits; PR built from a chore branch).

#### Rationale
- Centralize assistant-specific guidance without touching application logic
- Ensure consistent mode selection, tool usage, and safety rails when collaborating with the Junie agent

#### Impact / Risk
- Scope: docs/config only (new files under `junie/`)
- Risk: Low — no changes to Go modules, CI, or runtime code paths

#### Validation
- Local checks performed:
  - Branch pushed: `chore/add-junie-config`
  - Contracts validation OK (`eac validate contracts`)
  - Markdown validation reports existing repo-wide issues unrelated to these new files; none introduced by this PR’s additions
- CI expected to run full validation on PR

#### Checklist
- [x] Descriptive PR title (conventional commit)  
- [x] Clear description and rationale  
- [x] No production code changes  
- [x] Contracts validation OK locally  
- [ ] CI checks green  
- [ ] Review complete