### PR TITLE
fix: silence pedantic Cgo warnings on macOS via importer.sh

### DIFF
--- a/importer.sh
+++ b/importer.sh
@@ -36,6 +36,12 @@ if [ -n "$RUN_WELCOME_EMITTED" ]; then
     SHOW_WELCOME=0
 fi
 
+# Silence pedantic Cgo warnings from dependencies (e.g. go-m1cpu) on macOS
+# This affects the current shell session only.
+if [ "$(uname)" = "Darwin" ]; then
+    export CGO_CFLAGS="-Wno-gnu-folding-constant"
+fi
+
 # Get script directory and module path
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MODULE_PATH="$SCRIPT_DIR/scripts/sh/go-invoker/go.sh"


### PR DESCRIPTION
Silences the pedantic Cgo warnings (variable length array folded to constant array) that occur when compiling dependencies like go-m1cpu on macOS. This is achieved by exporting CGO_CFLAGS='-Wno-gnu-folding-constant' in importer.sh when running on Darwin. This ensures the warnings are silenced for the contributor's session without affecting other projects.